### PR TITLE
Fix typo in package name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [project]
-name = "venmo-api-unoffical"
+name = "venmo-api-unofficial"
 version = ""
 description = "A python client to the undocumented Venmo API"
 authors = [


### PR DESCRIPTION
Fix an error when installing this library in a Poetry project:

```
  The dependency name for venmo-api-unofficial does not match the actual package's name: venmo-api-unoffical
```